### PR TITLE
Functions for saving and loading CohortSubsetDefinitions in cohortGenerator module

### DIFF
--- a/Main.R
+++ b/Main.R
@@ -194,16 +194,7 @@ getModuleInfo <- function() {
   return(ParallelLogger::loadSettingsFromJson("MetaData.json"))
 }
 
-createCohortDefinitionSetFromJobContext <- function(sharedResources, settings) {
-  cohortDefinitions <- list()
-  if (length(sharedResources) <= 0) {
-    stop("No shared resources found")
-  }
-  cohortDefinitionSharedResource <- getSharedResourceByClassName(sharedResources = sharedResources, 
-                                                                 class = "CohortDefinitionSharedResources")
-  if (is.null(cohortDefinitionSharedResource)) {
-    stop("Cohort definition shared resource not found!")
-  }
+.getCohortDefinitionSetFromSharedResource <- function(cohortDefinitionSharedResource) {
   cohortDefinitions <- cohortDefinitionSharedResource$cohortDefinitions
   if (length(cohortDefinitions) <= 0) {
     stop("No cohort definitions found")
@@ -228,7 +219,20 @@ createCohortDefinitionSetFromJobContext <- function(sharedResources, settings) {
       cohortDefinitionSet <-  CohortGenerator::addCohortSubsetDefinition(cohortDefinitionSet, subsetDef)
     }
   }
+}
+
+createCohortDefinitionSetFromJobContext <- function(sharedResources, settings) {
+  cohortDefinitions <- list()
+  if (length(sharedResources) <= 0) {
+    stop("No shared resources found")
+  }
+  cohortDefinitionSharedResource <- getSharedResourceByClassName(sharedResources = sharedResources, 
+                                                                 class = "CohortDefinitionSharedResources")
+  if (is.null(cohortDefinitionSharedResource)) {
+    stop("Cohort definition shared resource not found!")
+  }
   
+  cohortDefinitionSet <- .getCohortDefinitionSetFromSharedResource(cohortDefinitionSharedResource)
   return(cohortDefinitionSet)
 }
 

--- a/Main.R
+++ b/Main.R
@@ -221,6 +221,14 @@ createCohortDefinitionSetFromJobContext <- function(sharedResources, settings) {
       stringsAsFactors = FALSE
     ))
   }
+  
+  if (length(cohortDefinitionSharedResource$subsetDefinitions)) {
+    subsetDefinitions <- lapply(cohortDefinitionSharedResource$subsetDefinitions, CohortGenerator::CohortSubsetDefinition$new)
+    for (subsetDef in subsetDefinitions) {
+      cohortDefinitionSet <-  CohortGenerator::addCohortSubsetDefinition(cohortDefinitionSet, subsetDef)
+    }
+  }
+  
   return(cohortDefinitionSet)
 }
 

--- a/Main.R
+++ b/Main.R
@@ -206,7 +206,7 @@ getModuleInfo <- function() {
     cohortExpression <- CirceR::cohortExpressionFromJson(cohortJson)
     cohortSql <- CirceR::buildCohortQuery(cohortExpression, options = CirceR::createGenerateOptions(generateStats = settings$generateStats))
     cohortDefinitionSet <- rbind(cohortDefinitionSet, data.frame(
-      cohortId = as.integer(cohortDefinitions[[i]]$cohortId),
+      cohortId = as.double(cohortDefinitions[[i]]$cohortId),
       cohortName = cohortDefinitions[[i]]$cohortName,
       sql = cohortSql,
       json = cohortJson,
@@ -220,6 +220,8 @@ getModuleInfo <- function() {
       cohortDefinitionSet <-  CohortGenerator::addCohortSubsetDefinition(cohortDefinitionSet, subsetDef)
     }
   }
+  
+  return(cohortDefinitionSet)
 }
 
 createCohortDefinitionSetFromJobContext <- function(sharedResources, settings) {

--- a/Main.R
+++ b/Main.R
@@ -194,7 +194,8 @@ getModuleInfo <- function() {
   return(ParallelLogger::loadSettingsFromJson("MetaData.json"))
 }
 
-.getCohortDefinitionSetFromSharedResource <- function(cohortDefinitionSharedResource) {
+# This private function makes testing the call bit easier
+.getCohortDefinitionSetFromSharedResource <- function(cohortDefinitionSharedResource, settings) {
   cohortDefinitions <- cohortDefinitionSharedResource$cohortDefinitions
   if (length(cohortDefinitions) <= 0) {
     stop("No cohort definitions found")
@@ -232,7 +233,7 @@ createCohortDefinitionSetFromJobContext <- function(sharedResources, settings) {
     stop("Cohort definition shared resource not found!")
   }
   
-  cohortDefinitionSet <- .getCohortDefinitionSetFromSharedResource(cohortDefinitionSharedResource)
+  cohortDefinitionSet <- .getCohortDefinitionSetFromSharedResource(cohortDefinitionSharedResource, settings)
   return(cohortDefinitionSet)
 }
 

--- a/SettingsFunctions.R
+++ b/SettingsFunctions.R
@@ -60,7 +60,7 @@ createCohortSharedResourceSpecifications <- function(cohortDefinitionSet) {
   
   subsetDefinitions <- CohortGenerator::getSubsetDefinitions(cohortDefinitionSet)
   if (length(subsetDefinitions)) {
-    sharedResource$subsetDefinitions <- lapply(subsetDefinitions, x$toJSON())
+    sharedResource$subsetDefinitions <- lapply(subsetDefinitions, function(x) x$toJSON())
     cohortDefinitionSet <- cohortDefinitionSet[!cohortDefinitionSet$isSubset, ]
   }
   

--- a/SettingsFunctions.R
+++ b/SettingsFunctions.R
@@ -60,7 +60,7 @@ createCohortSharedResourceSpecifications <- function(cohortDefinitionSet) {
   
   subsetDefinitions <- CohortGenerator::getSubsetDefinitions(cohortDefinitionSet)
   if (length(subsetDefinitions)) {
-    sharedResource$subsetDefinitions <- lapply(subsetDefinitions, function(x) x$toJSON())
+    sharedResource$subsetDefinitions <- lapply(subsetDefinitions, function(x) { x$toJSON()})
     cohortDefinitionSet <- cohortDefinitionSet[!cohortDefinitionSet$isSubset, ]
   }
   

--- a/SettingsFunctions.R
+++ b/SettingsFunctions.R
@@ -55,11 +55,21 @@ createCohortSharedResourceSpecifications <- function(cohortDefinitionSet) {
   if (!CohortGenerator::isCohortDefinitionSet(cohortDefinitionSet)) {
     stop("cohortDefinitionSet is not properly defined")
   }
+  
+  sharedResource <- list()
+  
+  subsetDefinitions <- CohortGenerator::getSubsetDefinitions(cohortDefinitionSet)
+  if (length(subsetDefinitions)) {
+    sharedResource$subsetDefinitions <- lapply(subsetDefinitions, x$toJSON())
+    cohortDefinitionSet <- cohortDefinitionSet[!cohortDefinitionSet$isSubset, ]
+  }
+  
   cohortDefinitionSet <- cohortDefinitionSet[,c("cohortId", "cohortName", "json")]
   names(cohortDefinitionSet) <- c("cohortId", "cohortName", "cohortDefinition")
   print(cohortDefinitionSet[,c("cohortId", "cohortName")])
   cohortDefinitionSet <- apply(cohortDefinitionSet, 1, as.list)
-  sharedResource <- list(cohortDefinitions = cohortDefinitionSet)
+  sharedResource$cohortDefinitions <- cohortDefinitionSet
+   
   class(sharedResource) <- c("CohortDefinitionSharedResources", "SharedResources")
   return(sharedResource)
 }


### PR DESCRIPTION
This will load and save cohort definition sets in shared resources.

Some notes:

* Will require CohortDefinitionSet code (currently in a branch of CohortGenerator)
* I changed cohortId from as.integer to as.double. This is because integer fails the 64 bit check in `CohortGenerator::isCohortDefinitionSet`
* To get cohortIds and cohorts the cohortDefinitionSet shared resource must be passed down to other strategues modules. I haven't tested if that is the case, if it's not this could create problems but it should be solvable
